### PR TITLE
Handle EPIPE errors along with the current ECONNRESET

### DIFF
--- a/javascript/node/selenium-webdriver/http/index.js
+++ b/javascript/node/selenium-webdriver/http/index.js
@@ -226,7 +226,7 @@ function sendRequest(options, onOk, onError, opt_data, opt_proxy) {
   });
 
   request.on('error', function(e) {
-    if (e.code === 'ECONNRESET') {
+    if (e.code === 'ECONNRESET' || e.code === 'EPIPE') {
       setTimeout(function() {
         sendRequest(options, onOk, onError, opt_data, opt_proxy);
       }, 15);


### PR DESCRIPTION
- [ X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

There is an open issue with Node.js throwing EPIPE errors when you pipe to a closed stream.  This was causing me unpredictable errors while loading pages.

The errors are pretty similar to ECONNRESET in the sense that you could simply try again and shouldn't throw every time it happens.

More info here: https://github.com/nodejs/node/issues/947